### PR TITLE
ZEN-4509 Fix security vulnerability from Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-version}</version>
+                <version>${jackson-version}.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -451,7 +451,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <jackson-version>2.8.2</jackson-version>
+        <jackson-version>2.8.11</jackson-version>
         <nexus.autorelease>false</nexus.autorelease>
         <nexus.autodrop>true</nexus.autodrop>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Recommendation was to upgrade to v2.8.11.1 or greater for
jackson-databind package. Latest available version prior to 2.9 is
2.8.11.2, so went with that. Other jackson packages do not have
2.8.11.2, so used 2.8.11 for them.

Not moving to 2.9.x yet to avoid getting too far out in front of what
will be used in API Studio due to bundle configruations, constrained by
orbit bundles in use.