### PR TITLE
ZEN-4513 Support custom gentemplates in API Studio

### DIFF
--- a/modules/genflow-api/pom.xml
+++ b/modules/genflow-api/pom.xml
@@ -39,7 +39,7 @@
         <connection>scm:git:git://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/genflow-api</url>
-        <tag>v0.0.18</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencies>
         <dependency>
@@ -132,7 +132,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/modules/genflow-api/pom.xml
+++ b/modules/genflow-api/pom.xml
@@ -39,7 +39,7 @@
         <connection>scm:git:git://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/genflow-api</url>
-        <tag>HEAD</tag>
+        <tag>v0.0.18</tag>
     </scm>
     <dependencies>
         <dependency>
@@ -132,7 +132,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/target/GenTarget.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/target/GenTarget.java
@@ -232,7 +232,7 @@ public class GenTarget {
 		}
 		if (genTemplate == null) {
 			try {
-				genTemplate = GenTemplateRegistry.getGenTemplate(genTemplateId).getInstance();
+				genTemplate = GenTemplateRegistry.getDefaultGenTemplate(genTemplateId).getInstance();
 			} catch (Throwable e) {
 				logger.severe("Failed to locate GenTemplate " + genTemplateId);
 				e.printStackTrace();

--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/target/GenTargetUtils.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/target/GenTargetUtils.java
@@ -139,7 +139,7 @@ public final class GenTargetUtils {
 	}
 
 	private static String getProvider(GenTarget target) throws GenerationException {
-		IGenTemplate template = GenTemplateRegistry.getGenTemplate(target.getGenTemplateId()).getInstance();
+		IGenTemplate template = GenTemplateRegistry.getDefaultGenTemplate(target.getGenTemplateId()).getInstance();
 		String unknown = "unknown provider";
 		if (template == null) {
 			return unknown;

--- a/modules/gentemplates/common/pom.xml
+++ b/modules/gentemplates/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>genflow-common</name>
@@ -45,7 +45,7 @@
         <connection>scm:git:gimodulet://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/gentemplates/common</url>
-        <tag>HEAD</tag>
+        <tag>v0.0.18</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/modules/gentemplates/common/pom.xml
+++ b/modules/gentemplates/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>genflow-common</name>
@@ -45,7 +45,7 @@
         <connection>scm:git:gimodulet://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/gentemplates/common</url>
-        <tag>v0.0.18</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/modules/gentemplates/openapi-diagram/pom.xml
+++ b/modules/gentemplates/openapi-diagram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
     <artifactId>openapi-diagram</artifactId>

--- a/modules/gentemplates/openapi-diagram/pom.xml
+++ b/modules/gentemplates/openapi-diagram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../../</relativePath>
     </parent>
     <artifactId>openapi-diagram</artifactId>

--- a/modules/gentemplates/openapi-generator/pom.xml
+++ b/modules/gentemplates/openapi-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>openapi-generator</artifactId>

--- a/modules/gentemplates/openapi-generator/pom.xml
+++ b/modules/gentemplates/openapi-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>openapi-generator</artifactId>

--- a/modules/gentemplates/openapi-normalizer/pom.xml
+++ b/modules/gentemplates/openapi-normalizer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>openapi-normalizer</artifactId>

--- a/modules/gentemplates/openapi-normalizer/pom.xml
+++ b/modules/gentemplates/openapi-normalizer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>openapi-normalizer</artifactId>

--- a/modules/gentemplates/openapi3-doc/pom.xml
+++ b/modules/gentemplates/openapi3-doc/pom.xml
@@ -36,7 +36,7 @@
         <connection>scm:git:git://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/gentemplates/openapi3-doc</url>
-        <tag>HEAD</tag>
+        <tag>v0.0.18</tag>
     </scm>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -45,7 +45,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/modules/gentemplates/openapi3-doc/pom.xml
+++ b/modules/gentemplates/openapi3-doc/pom.xml
@@ -36,7 +36,7 @@
         <connection>scm:git:git://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/gentemplates/openapi3-doc</url>
-        <tag>v0.0.18</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -45,7 +45,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/modules/gentemplates/rapidml-csharp/pom.xml
+++ b/modules/gentemplates/rapidml-csharp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-csharp</artifactId>

--- a/modules/gentemplates/rapidml-csharp/pom.xml
+++ b/modules/gentemplates/rapidml-csharp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-csharp</artifactId>

--- a/modules/gentemplates/rapidml-diagram/pom.xml
+++ b/modules/gentemplates/rapidml-diagram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-diagram</artifactId>

--- a/modules/gentemplates/rapidml-diagram/pom.xml
+++ b/modules/gentemplates/rapidml-diagram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-diagram</artifactId>

--- a/modules/gentemplates/rapidml-doc/pom.xml
+++ b/modules/gentemplates/rapidml-doc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-doc</artifactId>

--- a/modules/gentemplates/rapidml-doc/pom.xml
+++ b/modules/gentemplates/rapidml-doc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-doc</artifactId>

--- a/modules/gentemplates/rapidml-jaxrs/pom.xml
+++ b/modules/gentemplates/rapidml-jaxrs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-jaxrs</artifactId>

--- a/modules/gentemplates/rapidml-jaxrs/pom.xml
+++ b/modules/gentemplates/rapidml-jaxrs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-jaxrs</artifactId>

--- a/modules/gentemplates/rapidml-jsonschema/pom.xml
+++ b/modules/gentemplates/rapidml-jsonschema/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-jsonschema</artifactId>

--- a/modules/gentemplates/rapidml-jsonschema/pom.xml
+++ b/modules/gentemplates/rapidml-jsonschema/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-jsonschema</artifactId>

--- a/modules/gentemplates/rapidml-nodejs/pom.xml
+++ b/modules/gentemplates/rapidml-nodejs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-nodejs</artifactId>

--- a/modules/gentemplates/rapidml-nodejs/pom.xml
+++ b/modules/gentemplates/rapidml-nodejs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-nodejs</artifactId>

--- a/modules/gentemplates/rapidml-swagger/pom.xml
+++ b/modules/gentemplates/rapidml-swagger/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-swagger</artifactId>

--- a/modules/gentemplates/rapidml-swagger/pom.xml
+++ b/modules/gentemplates/rapidml-swagger/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-swagger</artifactId>

--- a/modules/gentemplates/rapidml-wadl/pom.xml
+++ b/modules/gentemplates/rapidml-wadl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-wadl</artifactId>

--- a/modules/gentemplates/rapidml-wadl/pom.xml
+++ b/modules/gentemplates/rapidml-wadl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-wadl</artifactId>

--- a/modules/gentemplates/rapidml-xsd/pom.xml
+++ b/modules/gentemplates/rapidml-xsd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-xsd</artifactId>

--- a/modules/gentemplates/rapidml-xsd/pom.xml
+++ b/modules/gentemplates/rapidml-xsd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-xsd</artifactId>

--- a/modules/gentemplates/swagger-codegen/pom.xml
+++ b/modules/gentemplates/swagger-codegen/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-codegen</artifactId>

--- a/modules/gentemplates/swagger-codegen/pom.xml
+++ b/modules/gentemplates/swagger-codegen/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-codegen</artifactId>

--- a/modules/gentemplates/swagger-doc/pom.xml
+++ b/modules/gentemplates/swagger-doc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
     <artifactId>swagger-doc</artifactId>

--- a/modules/gentemplates/swagger-doc/pom.xml
+++ b/modules/gentemplates/swagger-doc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../../</relativePath>
     </parent>
     <artifactId>swagger-doc</artifactId>

--- a/modules/gentemplates/swagger-nswag/pom.xml
+++ b/modules/gentemplates/swagger-nswag/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-nswag</artifactId>

--- a/modules/gentemplates/swagger-nswag/pom.xml
+++ b/modules/gentemplates/swagger-nswag/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-nswag</artifactId>

--- a/modules/gentemplates/swagger-ui/pom.xml
+++ b/modules/gentemplates/swagger-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-ui</artifactId>

--- a/modules/gentemplates/swagger-ui/pom.xml
+++ b/modules/gentemplates/swagger-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-ui</artifactId>

--- a/modules/standard-gentemplates/pom.xml
+++ b/modules/standard-gentemplates/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../..</relativePath>
     </parent>
     <packaging>pom</packaging>
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/standard-gentemplates</url>
-        <tag>HEAD</tag>
+        <tag>v0.0.18</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/modules/standard-gentemplates/pom.xml
+++ b/modules/standard-gentemplates/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <packaging>pom</packaging>
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:ssh://github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/tree/master/modules/standard-gentemplates</url>
-        <tag>v0.0.18</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18</version>
+        <version>0.0.19-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>genflow-tools</artifactId>

--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>0.0.18-SNAPSHOT</version>
+        <version>0.0.18</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>genflow-tools</artifactId>

--- a/modules/tools/src/main/java/com/reprezen/genflow/tools/GenTool.java
+++ b/modules/tools/src/main/java/com/reprezen/genflow/tools/GenTool.java
@@ -69,7 +69,7 @@ public class GenTool {
 			glob = glob.map(String::toLowerCase)
 					.map(g -> (g.startsWith("*") ? "" : "*") + g + (g.endsWith("*") ? "" : "*"));
 			PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + glob.get());
-			List<GenTemplateInfo> matches = GenTemplateRegistry.getGenTemplates(false).stream()
+			List<GenTemplateInfo> matches = GenTemplateRegistry.getDefaultGenTemplates(false).stream()
 					.filter(t -> matcher.matches(Paths.get(t.getId().toLowerCase())))
 					.sorted((a, b) -> a.getId().compareTo(b.getId())).collect(Collectors.toList());
 			if (matches.size() == 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.reprezen.genflow</groupId>
     <artifactId>genflow</artifactId>
-    <version>0.0.18</version>
+    <version>0.0.19-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>GenFlow</name>
     <description>RepreZen GenFlow Framework</description>
@@ -43,7 +43,7 @@
         <connection>scm:git:git@github.com:RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:git@github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/master</url>
-        <tag>v0.0.18</tag>
+        <tag>HEAD</tag>
     </scm>
     <modules>
         <module>modules/genflow-api</module>
@@ -262,12 +262,12 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>genflow-api</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>genflow-common</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.openapitools</groupId>
@@ -282,7 +282,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>standard-gentemplates</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
                 <type>pom</type>
             </dependency>
             <dependency>
@@ -293,7 +293,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-codegen</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -303,32 +303,32 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-diagram</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-generator</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi3-doc</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-doc</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-normalizer</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-ui</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.rapidml</groupId>
@@ -358,22 +358,22 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-doc</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-diagram</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-xsd</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-wadl</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.raml</groupId>
@@ -388,17 +388,17 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-jsonschema</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-swagger</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-csharp</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -408,7 +408,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-nodejs</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
@@ -433,12 +433,12 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-jaxrs</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-nswag</artifactId>
-                <version>0.0.18</version>
+                <version>0.0.19-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.reprezen.genflow</groupId>
     <artifactId>genflow</artifactId>
-    <version>0.0.18-SNAPSHOT</version>
+    <version>0.0.18</version>
     <packaging>pom</packaging>
     <name>GenFlow</name>
     <description>RepreZen GenFlow Framework</description>
@@ -43,7 +43,7 @@
         <connection>scm:git:git@github.com:RepreZen/GenFlow.git</connection>
         <developerConnection>scm:git:git@github.com:RepreZen/GenFlow.git</developerConnection>
         <url>https://github.com/RepreZen/GenFlow/master</url>
-        <tag>HEAD</tag>
+        <tag>v0.0.18</tag>
     </scm>
     <modules>
         <module>modules/genflow-api</module>
@@ -262,12 +262,12 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>genflow-api</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>genflow-common</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>org.openapitools</groupId>
@@ -282,7 +282,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>standard-gentemplates</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
                 <type>pom</type>
             </dependency>
             <dependency>
@@ -293,7 +293,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-codegen</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -303,32 +303,32 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-diagram</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-generator</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi3-doc</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-doc</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-normalizer</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-ui</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.rapidml</groupId>
@@ -358,22 +358,22 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-doc</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-diagram</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-xsd</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-wadl</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>org.raml</groupId>
@@ -388,17 +388,17 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-jsonschema</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-swagger</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-csharp</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -408,7 +408,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-nodejs</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
@@ -433,12 +433,12 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-jaxrs</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-nswag</artifactId>
-                <version>0.0.18-SNAPSHOT</version>
+                <version>0.0.18</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
GTR instances can now be created with a caller-supplied classloader,
which will be used for scans. The static instance is now called the
"default" instance, and methods that use it also incorporate "default"
in their names.

This was important for EclipseGenTemplateRegistry, so gentemplates
present in the workspace would be included.