### PR TITLE
ZEN-4536 Fix incorrect AKAid on migrated gentemplates

### DIFF
--- a/modules/gentemplates/swagger-doc/src/main/java/com/reprezen/genflow/swagger/doc/XSwaggerDocGenTemplate.java
+++ b/modules/gentemplates/swagger-doc/src/main/java/com/reprezen/genflow/swagger/doc/XSwaggerDocGenTemplate.java
@@ -12,7 +12,7 @@ public class XSwaggerDocGenTemplate extends SwaggerGenTemplate {
 
 	@Override
 	protected void configure() throws GenerationException {
-		alsoKnownAs("com.modelsolv.reprezen.generators.swaggerdoc.XSwaggerDocGenTemplate");
+		alsoKnownAs("com.modelsolv.reprezen.gentemplates.swaggerdoc.XSwaggerDocGenTemplate");
 		define(primarySource().ofType(SwaggerSource_DocNormalizerOptions.class));
 		define(outputItem().named("HTML").using(XGenerateSwaggerDoc.class).writing("${swagger.info.title}_doc.html"));
 		define(staticResource().copying("js").to("."));


### PR DESCRIPTION
One turned out to be mistaken - for swagger.doc gentemplate