### PR TITLE
Don't let a single bad gentemplate kill the scan

### DIFF
--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/template/GenTemplateRegistry.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/template/GenTemplateRegistry.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
@@ -22,116 +21,116 @@ import org.slf4j.LoggerFactory;
 import com.reprezen.genflow.api.GenerationException;
 
 /**
- * Registry to discover generation templates. Can be used only in non-Eclipse
- * environment.
+ * Registry to discover generation templates. Can be used only in non-Eclipse environment.
  * 
  * @author Konstantin Zaitsev
  * @date May 18, 2015
  */
 public final class GenTemplateRegistry {
 
-	private static Logger logger = LoggerFactory.getLogger(GenTemplateRegistry.class);
+    private static Logger logger = LoggerFactory.getLogger(GenTemplateRegistry.class);
 
-	/** Singleton reference. */
-	private static GenTemplateRegistry defaultInstance = null;
-	private ClassLoader classLoader;
+    /** Singleton reference. */
+    private static GenTemplateRegistry defaultInstance = null;
+    private ClassLoader classLoader;
 
-	private Map<String, GenTemplateInfo> registry = null;
+    private Map<String, GenTemplateInfo> registry = null;
 
-	public GenTemplateRegistry() {
-		this(GenTemplateRegistry.class.getClassLoader());
-	}
+    public GenTemplateRegistry() {
+        this(GenTemplateRegistry.class.getClassLoader());
+    }
 
-	public GenTemplateRegistry(ClassLoader classLoader) {
-		this.classLoader = classLoader;
-	}
+    public GenTemplateRegistry(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
 
-	private void register(IGenTemplate template) {
-		GenTemplateInfo info = new GenTemplateInfo(template);
-		if (register(info.getId(), info)) {
-			info.getAkaIds().forEach(id -> register(id, info));
-		}
-	}
+    private void register(IGenTemplate template) {
+        GenTemplateInfo info = new GenTemplateInfo(template);
+        if (register(info.getId(), info)) {
+            info.getAkaIds().forEach(id -> register(id, info));
+        }
+    }
 
-	private boolean register(String id, GenTemplateInfo info) {
-		if (!registry.containsKey(id)) {
-			registry.put(id, info);
-		} else {
-			logger.warn(String.format("Id '%s' for GenTemplate %s already in use; ignoring", id, info.getName()));
-			return false;
-		}
-		return true;
-	}
+    private boolean register(String id, GenTemplateInfo info) {
+        if (!registry.containsKey(id)) {
+            registry.put(id, info);
+        } else {
+            logger.warn(String.format("Id '%s' for GenTemplate %s already in use; ignoring", id, info.getName()));
+            return false;
+        }
+        return true;
+    }
 
-	private static GenTemplateRegistry getDefaultInstance() {
-		if (defaultInstance == null) {
-			synchronized (GenTemplateRegistry.class) {
-				if (defaultInstance == null) {
-					defaultInstance = new GenTemplateRegistry();
-				}
-			}
-		}
-		return defaultInstance;
-	}
+    private static GenTemplateRegistry getDefaultInstance() {
+        if (defaultInstance == null) {
+            synchronized (GenTemplateRegistry.class) {
+                if (defaultInstance == null) {
+                    defaultInstance = new GenTemplateRegistry();
+                }
+            }
+        }
+        return defaultInstance;
+    }
 
-	/**
-	 * @param id id of the gen template
-	 * @return the gen template by ID
-	 * @throws GenerationException
-	 */
+    /**
+     * @param id
+     *               id of the gen template
+     * @return the gen template by ID
+     * @throws GenerationException
+     */
 
-	public GenTemplateInfo getGenTemplate(String id) {
-		assert id != null;
-		scan(false);
-		if (registry.containsKey(id)) {
-			return registry.get(id);
-		}
-		throw new RuntimeException("Template " + id + " not found");
-	}
+    public GenTemplateInfo getGenTemplate(String id) {
+        assert id != null;
+        scan(false);
+        if (registry.containsKey(id)) {
+            return registry.get(id);
+        }
+        throw new RuntimeException("Template " + id + " not found");
+    }
 
-	public static GenTemplateInfo getDefaultGenTemplate(String id) {
-		return getDefaultInstance().getGenTemplate(id);
-	}
+    public static GenTemplateInfo getDefaultGenTemplate(String id) {
+        return getDefaultInstance().getGenTemplate(id);
+    }
 
-	private void scan(boolean force) {
-		if (registry == null || force) {
-			registry = new HashMap<>();
-			Iterator<IGenTemplate> genTemplates = ServiceLoader.load(IGenTemplate.class, classLoader).iterator();
-			while (genTemplates.hasNext()) {
-				try {
-					IGenTemplate template = genTemplates.next();
-					register(template);
-				} catch (ServiceConfigurationError e) {
-					logger.warn("Could not retrieve gentemplate; skipping", e);
-				}
-			}
-			Iterator<IGenTemplateGroup> groups = ServiceLoader.load(IGenTemplateGroup.class).iterator();
-			while (groups.hasNext()) {
-				try {
-					IGenTemplateGroup templateGroup = groups.next();
-					Iterator<IGenTemplate> groupIterator = templateGroup.getGenTemplates(classLoader).iterator();
-					while (groupIterator.hasNext()) {
-						try {
-							IGenTemplate template = groupIterator.next();
-							register(template);
-						} catch (Exception e) {
-							logger.warn("Could not retrieve gentemplate from group; skipping", e);
-						}
-					}
-				} catch (Exception e) {
-					logger.warn("Could not retrieve gentemplate group); skipping", e);
-				}
-			}
-		}
-	}
+    private void scan(boolean force) {
+        if (registry == null || force) {
+            registry = new HashMap<>();
+            Iterator<IGenTemplate> genTemplates = ServiceLoader.load(IGenTemplate.class, classLoader).iterator();
+            while (genTemplates.hasNext()) {
+                try {
+                    IGenTemplate template = genTemplates.next();
+                    register(template);
+                } catch (Throwable e) {
+                    logger.warn("Could not retrieve gentemplate; skipping", e);
+                }
+            }
+            Iterator<IGenTemplateGroup> groups = ServiceLoader.load(IGenTemplateGroup.class).iterator();
+            while (groups.hasNext()) {
+                try {
+                    IGenTemplateGroup templateGroup = groups.next();
+                    Iterator<IGenTemplate> groupIterator = templateGroup.getGenTemplates(classLoader).iterator();
+                    while (groupIterator.hasNext()) {
+                        try {
+                            IGenTemplate template = groupIterator.next();
+                            register(template);
+                        } catch (Throwable e) {
+                            logger.warn("Could not retrieve gentemplate from group; skipping", e);
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.warn("Could not retrieve gentemplate group); skipping", e);
+                }
+            }
+        }
+    }
 
-	public List<GenTemplateInfo> getGenTemplates(boolean force) {
-		scan(force);
-		return registry.values().stream().distinct().collect(Collectors.toList());
+    public List<GenTemplateInfo> getGenTemplates(boolean force) {
+        scan(force);
+        return registry.values().stream().distinct().collect(Collectors.toList());
 
-	}
+    }
 
-	public static List<GenTemplateInfo> getDefaultGenTemplates(boolean force) {
-		return getDefaultInstance().getGenTemplates(force);
-	}
+    public static List<GenTemplateInfo> getDefaultGenTemplates(boolean force) {
+        return getDefaultInstance().getGenTemplates(force);
+    }
 }


### PR DESCRIPTION
Scans for individual gentemplates and for gentemplate groups were both
wrong, in different ways.

For individual scans, we were catching ServiceConfigError and skipping
the problematic gentemplate with a warning. That was missing exceptions
that could occur during creation of a GenTemplateInfo object from the
discovered GenTEemplate.

In the group scan we were catching Exception, but ServiceConfigError is
not an Exception, so a problematic group could likewise kill the whole
scan.

Now both scans catch Throwable, so no problematic single discovery
should be capable of killing everything.