### PR TITLE
Retain implicitly required security schemes

### DIFF
--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/normal/openapi/ContentManager.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/normal/openapi/ContentManager.java
@@ -1,10 +1,15 @@
 package com.reprezen.genflow.api.normal.openapi;
 
 import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Maps;
@@ -18,178 +23,202 @@ import com.reprezen.genflow.api.normal.openapi.ContentLocalizer.LocalContent;
  */
 public class ContentManager {
 
-	private final Integer modelVersion;
-	private final Map<String, Content> contentItems = Maps.newLinkedHashMap();
-	private final ContentLocalizer localizer;
-	private final Set<String> toBeLoaded = Sets.newLinkedHashSet();
+    private final Integer modelVersion;
+    private final Map<String, Content> contentItems = Maps.newLinkedHashMap();
+    private final ContentLocalizer localizer;
+    private final Set<String> toBeLoaded = Sets.newLinkedHashSet();
 
-	// following lets us avoid using URLs as set items or map keys, because
-	// URL#equals is potentially very expensive
-	// (involving network operations). And it gives us an exception-free way to
-	// translate from URL strings we know to be
-	// cached into the corresponding URLs.
-	private final Map<String, URL> urlCache = Maps.newHashMap();
+    // following lets us avoid using URLs as set items or map keys, because
+    // URL#equals is potentially very expensive
+    // (involving network operations). And it gives us an exception-free way to
+    // translate from URL strings we know to be
+    // cached into the corresponding URLs.
+    private final Map<String, URL> urlCache = Maps.newHashMap();
 
-	public ContentManager(Integer modelVersion) {
-		this.modelVersion = modelVersion;
-		this.localizer = new ContentLocalizer(modelVersion);
-	}
+    public ContentManager(Integer modelVersion) {
+        this.modelVersion = modelVersion;
+        this.localizer = new ContentLocalizer(modelVersion);
+    }
 
-	public Integer getModelVersion() {
-		return modelVersion;
-	}
+    public Integer getModelVersion() {
+        return modelVersion;
+    }
 
-	/**
-	 * Public load for the top-level model document.
-	 * <p>
-	 * This method may provide the preloaded tree corresponding to the specified
-	 * URL. E.g. this would generally be the case when a model spec in an open
-	 * editor is normalized. In such cases, the URL is still required so that
-	 * relative references appearing in that tree can be resolved.
-	 */
-	public Content load(URL url, JsonNode tree, boolean rewriteSimpleRefs) {
-		Content content = loadInternal(url, tree, rewriteSimpleRefs);
-		loadRequestedDocuments(rewriteSimpleRefs);
-		return content;
-	}
+    /**
+     * Public load for the top-level model document.
+     * <p>
+     * This method may provide the preloaded tree corresponding to the specified URL. E.g. this would generally be the
+     * case when a model spec in an open editor is normalized. In such cases, the URL is still required so that relative
+     * references appearing in that tree can be resolved.
+     */
+    public Content load(URL url, JsonNode tree, boolean rewriteSimpleRefs) {
+        Content content = loadInternal(url, tree, rewriteSimpleRefs);
+        loadRequestedDocuments(rewriteSimpleRefs);
+        return content;
+    }
 
-	/**
-	 * This private load method is used to load documents directly or indirectly
-	 * referenced by the top-level document. A preloaded tree is never provided in
-	 * this case.
-	 */
-	private Content loadRequestedDoc(URL url, boolean rewriteSimpleRefs) {
-		return loadInternal(url, null, rewriteSimpleRefs);
-	}
+    /**
+     * This private load method is used to load documents directly or indirectly referenced by the top-level document. A
+     * preloaded tree is never provided in this case.
+     */
+    private Content loadRequestedDoc(URL url, boolean rewriteSimpleRefs) {
+        return loadInternal(url, null, rewriteSimpleRefs);
+    }
 
-	/**
-	 * Load a JSON tree from the given URL (unless preloaded tree is provided),
-	 * register the content, and maybe rewrite "simple" refs to local object refs
-	 */
-	private Content loadInternal(URL url, JsonNode tree, boolean rewriteSimpleRefs) {
-		String urlString = cacheUrl(url);
-		Content content = contentItems.get(urlString);
-		if (content == null) {
-			content = new ContentLoader(this).load(url, tree, rewriteSimpleRefs);
-			contentItems.put(urlString, content);
-		}
-		return content;
-	}
+    /**
+     * Load a JSON tree from the given URL (unless preloaded tree is provided), register the content, and maybe rewrite
+     * "simple" refs to local object refs
+     */
+    private Content loadInternal(URL url, JsonNode tree, boolean rewriteSimpleRefs) {
+        String urlString = cacheUrl(url);
+        Content content = contentItems.get(urlString);
+        if (content == null) {
+            content = new ContentLoader(this).load(url, tree, rewriteSimpleRefs);
+            contentItems.put(urlString, content);
+        }
+        return content;
+    }
 
-	/**
-	 * Request that a document be loaded and registered with the content manager.
-	 * <p>
-	 * This will be called for every document (i.e. a reference minus its fragment)
-	 * referenced in any loaded document.
-	 */
+    /**
+     * Request that a document be loaded and registered with the content manager.
+     * <p>
+     * This will be called for every document (i.e. a reference minus its fragment) referenced in any loaded document.
+     */
 
-	public void requestDocument(URL url) {
-		toBeLoaded.add(cacheUrl(url));
-	}
+    public void requestDocument(URL url) {
+        toBeLoaded.add(cacheUrl(url));
+    }
 
-	/**
-	 * Load requested documents until there are no more newly requested documents.
-	 * <p>
-	 * During this method, more documents may be requested.
-	 */
-	private void loadRequestedDocuments(boolean rewriteSimpleRefs) {
-		while (!toBeLoaded.isEmpty()) {
-			String urlString = toBeLoaded.iterator().next();
-			toBeLoaded.remove(urlString);
-			if (!contentItems.containsKey(urlString)) {
-				loadRequestedDoc(urlCache.get(urlString), rewriteSimpleRefs);
-			}
-		}
-	}
+    /**
+     * Load requested documents until there are no more newly requested documents.
+     * <p>
+     * During this method, more documents may be requested.
+     */
+    private void loadRequestedDocuments(boolean rewriteSimpleRefs) {
+        while (!toBeLoaded.isEmpty()) {
+            String urlString = toBeLoaded.iterator().next();
+            toBeLoaded.remove(urlString);
+            if (!contentItems.containsKey(urlString)) {
+                loadRequestedDoc(urlCache.get(urlString), rewriteSimpleRefs);
+            }
+        }
+    }
 
-	public Iterable<Content> contentItems() {
-		return contentItems.values();
-	}
+    public Iterable<Content> contentItems() {
+        return contentItems.values();
+    }
 
-	public Optional<JsonNode> getModelObject(Reference ref) {
-		if (ref.isModelObjectRef()) {
-			String urlString = cacheUrl(ref.getUrl());
-			Content content = contentItems.get(urlString);
-			if (content != null) {
-				return content.getObject(ref.getSection(), ref.getObjectName());
-			}
-		}
-		return Optional.empty();
-	}
+    public Optional<JsonNode> getModelObject(Reference ref) {
+        if (ref.isModelObjectRef()) {
+            String urlString = cacheUrl(ref.getUrl());
+            Content content = contentItems.get(urlString);
+            if (content != null) {
+                return content.getObject(ref.getSection(), ref.getObjectName());
+            }
+        }
+        return Optional.empty();
+    }
 
-	public Reference getLocalizedRef(Reference ref) {
-		Optional<JsonNode> node = getModelObject(ref);
-		if (node.isPresent()) {
-			localizer.register(ref, node.get());
-			return localizer.getLocalizedRef(ref);
-		} else {
-			return ref.getBadRef();
-		}
-	}
+    public Reference getLocalizedRef(Reference ref) {
+        Optional<JsonNode> node = getModelObject(ref);
+        if (node.isPresent()) {
+            localizer.register(ref, node.get());
+            return localizer.getLocalizedRef(ref);
+        } else {
+            return ref.getBadRef();
+        }
+    }
 
-	public JsonNode getLocalizedRefNode(Reference ref) {
-		Optional<JsonNode> node = getModelObject(ref);
-		if (node.isPresent()) {
-			localizer.register(ref, node.get());
-			return localizer.getLocalizedRefNode(ref);
-		} else {
-			return ref.getBadRefNode();
-		}
+    public JsonNode getLocalizedRefNode(Reference ref) {
+        Optional<JsonNode> node = getModelObject(ref);
+        if (node.isPresent()) {
+            localizer.register(ref, node.get());
+            return localizer.getLocalizedRefNode(ref);
+        } else {
+            return ref.getBadRefNode();
+        }
 
-	}
+    }
 
-	/**
-	 * Localize all the model objects in the given content item
-	 * <p>
-	 * This is used when to ensure that all model objects appearing in the top-level
-	 * spec will retain their original names in the final spec. Model objects
-	 * appearing in other specs may have their names changed for disambiguation.
-	 */
-	public void localizeObjects(Content content) {
-		for (ObjectType section : ObjectType.getTypesForVersion(modelVersion, Option.COMPONENT_OBJECTS)) {
-			localizeObjectsInSection(content, section);
-		}
-		localizeObjectsInSection(content, ObjectType.PATH);
-	}
+    /**
+     * Localize all the model objects in the given content item
+     * <p>
+     * This is used when to ensure that all model objects appearing in the top-level spec will retain their original
+     * names in the final spec. Model objects appearing in other specs may have their names changed for disambiguation.
+     */
+    public void localizeObjects(Content content) {
+        for (ObjectType section : ObjectType.getTypesForVersion(modelVersion, Option.COMPONENT_OBJECTS)) {
+            localizeObjectsInSection(content, section);
+        }
+        localizeObjectsInSection(content, ObjectType.PATH);
+    }
 
-	public void localizeObjectsInSection(Content content, ObjectType section) {
-		for (String objectName : content.getObjectNames(section)) {
-			Reference ref = content.getObjectReference(section, objectName);
-			JsonNode obj = content.getObject(section, objectName).get();
-			localizer.register(ref, obj);
-		}
-	}
+    public void localizeObjectsInSection(Content content, ObjectType section) {
+        for (String objectName : content.getObjectNames(section)) {
+            Reference ref = content.getObjectReference(section, objectName);
+            JsonNode obj = content.getObject(section, objectName).get();
+            localizer.register(ref, obj);
+        }
+    }
 
-	public ContentLocalizer getLocalizer() {
-		return localizer;
-	}
+    public ContentLocalizer getLocalizer() {
+        return localizer;
+    }
 
-	public void applyRetentionPolicy(RetentionPolicy policy) {
-		for (Entry<String, Content> e : contentItems.entrySet()) {
-			Content content = e.getValue();
-			for (ObjectType section : ObjectType.getTypesForVersion(modelVersion)) {
-				if (policy.shouldRetain(urlCache.get(e.getKey()), section)) {
-					retainObjectsInSection(content, section);
-				}
-			}
-		}
-	}
+    public void applyRetentionPolicy(RetentionPolicy policy) {
+        for (Entry<String, Content> e : contentItems.entrySet()) {
+            Content content = e.getValue();
+            for (ObjectType section : ObjectType.getTypesForVersion(modelVersion)) {
+                if (policy.shouldRetain(urlCache.get(e.getKey()), section)) {
+                    retainObjectsInSection(content, section);
+                }
+            }
+        }
+    }
 
-	private void retainObjectsInSection(Content content, ObjectType section) {
-		for (String objectName : content.getObjectNames(section)) {
-			Reference ref = content.getObjectReference(section, objectName);
-			JsonNode obj = content.getObject(section, objectName).get();
-			localizer.register(ref, obj).retain();
-		}
-	}
+    private void retainObjectsInSection(Content content, ObjectType section) {
+        for (String objectName : content.getObjectNames(section)) {
+            Reference ref = content.getObjectReference(section, objectName);
+            JsonNode obj = content.getObject(section, objectName).get();
+            localizer.register(ref, obj).retain();
+        }
+    }
 
-	public Optional<LocalContent> getAndRemoveRetainedModelObject() {
-		return localizer.getAndRemoveRetainedModelObject();
-	}
+    public void retainImplicitlyReferencedObjects() {
+        for (LocalContent item : localizer.getLocalContentItems()) {
+            if (item.isRetained()) {
+                if (item.getSectionType() == ObjectType.PATH && item.isRetained()) {
+                    for (LocalContent requiredScheme : getRequiredSecuritySchemes(item)) {
+                        requiredScheme.retain();
+                    }
+                }
+            }
+        }
+    }
 
-	private String cacheUrl(URL url) {
-		String key = url.toString();
-		urlCache.put(key, url);
-		return key;
-	}
+    private List<LocalContent> getRequiredSecuritySchemes(LocalContent path) {
+        JsonNode tree = path.getContent();
+        Set<String> reqs = new HashSet<>();
+        for (String meth : Arrays.asList("get", "put", "post", "delete", "options", "head", "patch", "trace")) {
+            if (tree.has(meth)) {
+                for (Iterator<JsonNode> reqIter = tree.get(meth).path("security").elements(); reqIter.hasNext();) {
+                    for (Iterator<String> nameIter = reqIter.next().fieldNames(); nameIter.hasNext();) {
+                        reqs.add(nameIter.next());
+                    }
+                }
+            }
+        }
+        return reqs.stream().map(name -> localizer.getLocalContent("/components/securitySchemes", name))
+                .filter(lc -> lc != null).collect(Collectors.toList());
+    }
+
+    public Optional<LocalContent> getAndRemoveRetainedModelObject() {
+        return localizer.getAndRemoveRetainedModelObject();
+    }
+
+    private String cacheUrl(URL url) {
+        String key = url.toString();
+        urlCache.put(key, url);
+        return key;
+    }
 }

--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/normal/openapi/OpenApiReferenceProcessor.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/normal/openapi/OpenApiReferenceProcessor.java
@@ -70,442 +70,441 @@ import io.swagger.util.Yaml;
  */
 public class OpenApiReferenceProcessor {
 
-	private final ContentManager contentManager;
-	private final RefVisitor refVisitor = new RefVisitor();
-	private static final ObjectMapper yamlMapper = Yaml.mapper();
+    private final ContentManager contentManager;
+    private final RefVisitor refVisitor = new RefVisitor();
+    private static final ObjectMapper yamlMapper = Yaml.mapper();
 
-	private JsonNode spec;
-	private final Options options;
-	private Integer modelVersion;
+    private JsonNode spec;
+    private final Options options;
+    private Integer modelVersion;
 
-	public OpenApiReferenceProcessor(Integer modelVersion, Option... options) {
-		this(Option.options(modelVersion, options));
-	}
+    public OpenApiReferenceProcessor(Integer modelVersion, Option... options) {
+        this(Option.options(modelVersion, options));
+    }
 
-	public OpenApiReferenceProcessor(Options options) {
-		this.options = options;
-		this.modelVersion = options.getModelVersion();
-		this.contentManager = new ContentManager(modelVersion);
-	}
+    public OpenApiReferenceProcessor(Options options) {
+        this.options = options;
+        this.modelVersion = options.getModelVersion();
+        this.contentManager = new ContentManager(modelVersion);
+    }
 
-	public OpenApiReferenceProcessor of(JsonNode spec) {
-		this.spec = spec;
-		return this;
-	}
+    public OpenApiReferenceProcessor of(JsonNode spec) {
+        this.spec = spec;
+        return this;
+    }
 
-	public OpenApiReferenceProcessor of(Swagger spec) {
-		return of(yamlMapper.valueToTree(spec));
-	}
+    public OpenApiReferenceProcessor of(Swagger spec) {
+        return of(yamlMapper.valueToTree(spec));
+    }
 
-	public OpenApiReferenceProcessor of(String spec) {
-		return of(DocLoader.toJson(spec, options.getModelVersion()));
-	}
+    public OpenApiReferenceProcessor of(String spec) {
+        return of(DocLoader.toJson(spec, options.getModelVersion()));
+    }
 
-	public JsonNode inline(URL base) throws GenerationException {
-		List<Content> badRoots = Lists.newArrayList();
-		if (options.isDoNotNormalize()) {
-			return spec;
-		}
-		// assemble top-level spec, and fault-in all referenced specs
-		Content topLevel = contentManager.load(base, spec, options.isRewriteSimpleRefs());
-		if (topLevel.isValid()) {
-			// reserve existing names for all top-level objects
-			contentManager.localizeObjects(topLevel);
-		} else {
-			badRoots.add(topLevel);
-		}
-		// set up retention policy and retain whatever needs it
-		RetentionPolicy retentionPolicy = new RetentionPolicy(topLevel, options);
-		// ensure that all other retained files are loaded as well, even if
-		// unreferenced,
-		// and reserve names
-		for (URL url : options.getAdditionalFileUrls()) {
-			Content content = contentManager.load(url, null, options.isRewriteSimpleRefs());
-			if (content.isValid()) {
-				contentManager.localizeObjects(content);
-			} else {
-				badRoots.add(content);
-			}
-		}
-		if (!badRoots.isEmpty()) {
-			throw new GenerationException("One or more root-level files could not be loaded:\n" + badRoots.stream()
-					.map(root -> String.format("%s: %s", root.getRefString(), root.getUnresolvedReason()))
-					.collect(Collectors.joining("\n")));
-		}
-		// retain all objects that should be and were not retained by referencing
-		contentManager.applyRetentionPolicy(retentionPolicy);
-		// fill in titles for untitled definitions, using the definition name
-		new DefinitionProcessor(contentManager).setTypeNames(options.isCreateDefTitles());
+    public JsonNode inline(URL base) throws GenerationException {
+        List<Content> badRoots = Lists.newArrayList();
+        if (options.isDoNotNormalize()) {
+            return spec;
+        }
+        // assemble top-level spec, and fault-in all referenced specs
+        Content topLevel = contentManager.load(base, spec, options.isRewriteSimpleRefs());
+        if (topLevel.isValid()) {
+            // reserve existing names for all top-level objects
+            contentManager.localizeObjects(topLevel);
+        } else {
+            badRoots.add(topLevel);
+        }
+        // set up retention policy and retain whatever needs it
+        RetentionPolicy retentionPolicy = new RetentionPolicy(topLevel, options);
+        // ensure that all other retained files are loaded as well, even if
+        // unreferenced,
+        // and reserve names
+        for (URL url : options.getAdditionalFileUrls()) {
+            Content content = contentManager.load(url, null, options.isRewriteSimpleRefs());
+            if (content.isValid()) {
+                contentManager.localizeObjects(content);
+            } else {
+                badRoots.add(content);
+            }
+        }
+        if (!badRoots.isEmpty()) {
+            throw new GenerationException("One or more root-level files could not be loaded:\n" + badRoots.stream()
+                    .map(root -> String.format("%s: %s", root.getRefString(), root.getUnresolvedReason()))
+                    .collect(Collectors.joining("\n")));
+        }
+        // retain all objects that should be and were not retained by referencing
+        contentManager.applyRetentionPolicy(retentionPolicy);
+        // retain objects that are required due to implicit references
+        contentManager.retainImplicitlyReferencedObjects();
+        // fill in titles for untitled definitions, using the definition name
+        new DefinitionProcessor(contentManager).setTypeNames(options.isCreateDefTitles());
 
-		// collect and process retained objects from all specs (including those faulted
-		// in while processing others),
-		// collecting them all in a new ObjectTree. The resulting tree will be complete,
-		// in that every resolvable
-		// reference contained in the tree will be a local reference to a model object
-		// in the tree. (And even
-		// unresolvable references will be local - i.e. pure JSON pointers)
-		ObjectNode tree = buildObjectTree();
+        // collect and process retained objects from all specs (including those faulted
+        // in while processing others),
+        // collecting them all in a new ObjectTree. The resulting tree will be complete,
+        // in that every resolvable
+        // reference contained in the tree will be a local reference to a model object
+        // in the tree. (And even
+        // unresolvable references will be local - i.e. pure JSON pointers)
+        ObjectNode tree = buildObjectTree();
 
-		// merge non-object content from the original top-level spec to newly built tree
-		addNonObjects(tree, topLevel.getTree());
+        // merge non-object content from the original top-level spec to newly built tree
+        addNonObjects(tree, topLevel.getTree());
 
-		// sort the tree according to requested ordering scheme
-		sortTree(tree);
+        // sort the tree according to requested ordering scheme
+        sortTree(tree);
 
-		// retain position information where we need it
-		markPositions(tree);
+        // retain position information where we need it
+        markPositions(tree);
 
-		return tree;
-	}
+        return tree;
+    }
 
-	private ObjectNode buildObjectTree() {
-		ObjectNode tree = JsonNodeFactory.instance.objectNode();
+    private ObjectNode buildObjectTree() {
+        ObjectNode tree = JsonNodeFactory.instance.objectNode();
 
-		while (true) {
-			Optional<LocalContent> optItem = contentManager.getAndRemoveRetainedModelObject();
-			if (optItem.isPresent()) {
-				LocalContent item = optItem.get();
-				JsonNode object = Util.safeDeepCopy(item.getContent());
-				object = inline(object, item.getRef());
-				OpenApiMarkers.markPosition(object, item.getPosition());
-				addToTree(tree, object, item.getSectionType(), item.getName());
-				addJsonPointers(object, item.getRef());
-			} else {
-				break;
-			}
-		}
-		return tree;
-	}
+        while (true) {
+            Optional<LocalContent> optItem = contentManager.getAndRemoveRetainedModelObject();
+            if (optItem.isPresent()) {
+                LocalContent item = optItem.get();
+                JsonNode object = Util.safeDeepCopy(item.getContent());
+                object = inline(object, item.getRef());
+                OpenApiMarkers.markPosition(object, item.getPosition());
+                addToTree(tree, object, item.getSectionType(), item.getName());
+                addJsonPointers(object, item.getRef());
+            } else {
+                break;
+            }
+        }
+        return tree;
+    }
 
-	private void addToTree(ObjectNode tree, JsonNode object, ObjectType sectionType, String objectName) {
-		if (sectionType.getFromNode(tree, modelVersion).isMissingNode()) {
-			sectionType.setInNode(tree, tree.objectNode(), modelVersion);
-		}
-		ObjectNode section = (ObjectNode) sectionType.getFromNode(tree, modelVersion);
-		section.set(objectName, object);
-	}
+    private void addToTree(ObjectNode tree, JsonNode object, ObjectType sectionType, String objectName) {
+        if (sectionType.getFromNode(tree, modelVersion).isMissingNode()) {
+            sectionType.setInNode(tree, tree.objectNode(), modelVersion);
+        }
+        ObjectNode section = (ObjectNode) sectionType.getFromNode(tree, modelVersion);
+        section.set(objectName, object);
+    }
 
-	private void addNonObjects(ObjectNode objectTree, JsonNode spec) {
-		for (Entry<String, JsonNode> field : Util.iterable(spec.fields())) {
-			String fieldName = field.getKey();
-			// Note: the following test assumes that the top-level property on the path to
-			// any container of model
-			// objects is itself an object container or is a JSON object that only contains
-			// object containers. This
-			// avoids what would be a much trickier test before copying a value from the
-			// top-level source model to the
-			// result model.
-			if (!ObjectType.isObjectContainerPrefix(fieldName, modelVersion)) {
-				objectTree.set(fieldName, Util.safeDeepCopy(field.getValue()));
-			}
-			//
-			// That assumption is NOT valid for v3 models, because the `components` property
-			// can contain vendor
-			// extensions. We fudge it by separately copying vendor extensions appearing in
-			// that property.
-			if (modelVersion == OPENAPI3_MODEL_VERSION && fieldName.equals("components")) {
-				addComponentExtensions(objectTree, spec);
-			}
-		}
-		// TODO V2?
-		if (ObjectType.PATH.getFromNode(objectTree, modelVersion).isMissingNode()) {
-			ObjectType.PATH.setInNode(objectTree, JsonNodeFactory.instance.objectNode(), modelVersion);
-		}
-	}
+    private void addNonObjects(ObjectNode objectTree, JsonNode spec) {
+        for (Entry<String, JsonNode> field : Util.iterable(spec.fields())) {
+            String fieldName = field.getKey();
+            // Note: the following test assumes that the top-level property on the path to
+            // any container of model
+            // objects is itself an object container or is a JSON object that only contains
+            // object containers. This
+            // avoids what would be a much trickier test before copying a value from the
+            // top-level source model to the
+            // result model.
+            if (!ObjectType.isObjectContainerPrefix(fieldName, modelVersion)) {
+                objectTree.set(fieldName, Util.safeDeepCopy(field.getValue()));
+            }
+            //
+            // That assumption is NOT valid for v3 models, because the `components` property
+            // can contain vendor
+            // extensions. We fudge it by separately copying vendor extensions appearing in
+            // that property.
+            if (modelVersion == OPENAPI3_MODEL_VERSION && fieldName.equals("components")) {
+                addComponentExtensions(objectTree, spec);
+            }
+        }
+        // TODO V2?
+        if (ObjectType.PATH.getFromNode(objectTree, modelVersion).isMissingNode()) {
+            ObjectType.PATH.setInNode(objectTree, JsonNodeFactory.instance.objectNode(), modelVersion);
+        }
+    }
 
-	private static final String COMPONENTS_FIELD = "components";
+    private static final String COMPONENTS_FIELD = "components";
 
-	private void addComponentExtensions(ObjectNode tree, JsonNode spec) {
-		for (Entry<String, JsonNode> field : Util.iterable(spec.get(COMPONENTS_FIELD).fields())) {
-			String fieldName = field.getKey();
-			if (fieldName.startsWith("x-")) {
-				if (!tree.has(COMPONENTS_FIELD)) {
-					tree.set(COMPONENTS_FIELD, JsonNodeFactory.instance.objectNode());
-				}
-				ObjectNode components = (ObjectNode) tree.get(COMPONENTS_FIELD);
-				components.set(fieldName, Util.safeDeepCopy(field.getValue()));
-			}
-		}
-	}
+    private void addComponentExtensions(ObjectNode tree, JsonNode spec) {
+        for (Entry<String, JsonNode> field : Util.iterable(spec.get(COMPONENTS_FIELD).fields())) {
+            String fieldName = field.getKey();
+            if (fieldName.startsWith("x-")) {
+                if (!tree.has(COMPONENTS_FIELD)) {
+                    tree.set(COMPONENTS_FIELD, JsonNodeFactory.instance.objectNode());
+                }
+                ObjectNode components = (ObjectNode) tree.get(COMPONENTS_FIELD);
+                components.set(fieldName, Util.safeDeepCopy(field.getValue()));
+            }
+        }
+    }
 
-	private void addJsonPointers(JsonNode object, Reference ref) {
-		if (options.isAddJsonPointers()) {
-			OpenApiMarkers.markJsonPointer(object, ref.getFragment());
-			if (ObjectType.PATH == ref.getSection()) {
-				Iterator<String> fields = object.fieldNames();
-				while (fields.hasNext()) {
-					String fieldName = fields.next();
-					if (Util.swaggerMethodOrder.contains(fieldName)) {
-						// was not set by external reference processor
-						if (RepreZenVendorExtension.get(object.get(fieldName)).getPointer() == null) {
-							OpenApiMarkers.markJsonPointer(object.get(fieldName), ref.getFragment() + "/" + fieldName);
-						}
+    private void addJsonPointers(JsonNode object, Reference ref) {
+        if (options.isAddJsonPointers()) {
+            OpenApiMarkers.markJsonPointer(object, ref.getFragment());
+            if (ObjectType.PATH == ref.getSection()) {
+                Iterator<String> fields = object.fieldNames();
+                while (fields.hasNext()) {
+                    String fieldName = fields.next();
+                    if (Util.swaggerMethodOrder.contains(fieldName)) {
+                        // was not set by external reference processor
+                        if (RepreZenVendorExtension.get(object.get(fieldName)).getPointer() == null) {
+                            OpenApiMarkers.markJsonPointer(object.get(fieldName), ref.getFragment() + "/" + fieldName);
+                        }
 
-					}
-				}
-			}
-		}
-	}
+                    }
+                }
+            }
+        }
+    }
 
-	private void addRefFileUrls(JsonNode object, Reference ref) {
-		if (options.isAddJsonPointers()) {
-			OpenApiMarkers.markFile(object, ref.getCanonicalFileRefString());
-			if (ObjectType.PATH == ref.getSection()) {
-				Iterator<String> fields = object.fieldNames();
-				String pathFileRef = ref.getCanonicalFileRefString();
-				while (fields.hasNext()) {
-					String fieldName = fields.next();
-					if (Util.swaggerMethodOrder.contains(fieldName)) {
-						if (pathFileRef != null) {
-							OpenApiMarkers.markFile(object.get(fieldName), pathFileRef);
-							OpenApiMarkers.markJsonPointer(object.get(fieldName), ref.getFragment() + "/" + fieldName);
-						}
-					}
-				}
-			}
-		}
-	}
+    private void addRefFileUrls(JsonNode object, Reference ref) {
+        if (options.isAddJsonPointers()) {
+            OpenApiMarkers.markFile(object, ref.getCanonicalFileRefString());
+            if (ObjectType.PATH == ref.getSection()) {
+                Iterator<String> fields = object.fieldNames();
+                String pathFileRef = ref.getCanonicalFileRefString();
+                while (fields.hasNext()) {
+                    String fieldName = fields.next();
+                    if (Util.swaggerMethodOrder.contains(fieldName)) {
+                        if (pathFileRef != null) {
+                            OpenApiMarkers.markFile(object.get(fieldName), pathFileRef);
+                            OpenApiMarkers.markJsonPointer(object.get(fieldName), ref.getFragment() + "/" + fieldName);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	private void sortTree(ObjectNode tree) {
-		if (options.isAsDeclaredOrdering()) {
-			// nothing to do
-		} else if (options.isSortedOrdering()) {
-			sort(tree);
-		}
-	}
+    private void sortTree(ObjectNode tree) {
+        if (options.isAsDeclaredOrdering()) {
+            // nothing to do
+        } else if (options.isSortedOrdering()) {
+            sort(tree);
+        }
+    }
 
-	private void sort(ObjectNode tree) {
+    private void sort(ObjectNode tree) {
 
-		for (ObjectType sectionType : ObjectType.getTypesForVersion(modelVersion)) {
-			JsonNode section = sectionType.getFromNode(tree, modelVersion);
-			if (!section.isMissingNode()) {
-				sortSection(section);
-				if (sectionType == ObjectType.PATH) {
-					for (Entry<String, JsonNode> path : Util.iterable(section.fields())) {
-						sortInPath(path.getValue());
-					}
-				}
-			}
-		}
-	}
+        for (ObjectType sectionType : ObjectType.getTypesForVersion(modelVersion)) {
+            JsonNode section = sectionType.getFromNode(tree, modelVersion);
+            if (!section.isMissingNode()) {
+                sortSection(section);
+                if (sectionType == ObjectType.PATH) {
+                    for (Entry<String, JsonNode> path : Util.iterable(section.fields())) {
+                        sortInPath(path.getValue());
+                    }
+                }
+            }
+        }
+    }
 
-	private static Pattern namePat = Pattern.compile("(.+)_(\\d+)");
+    private static Pattern namePat = Pattern.compile("(.+)_(\\d+)");
 
-	private void sortSection(JsonNode section) {
-		List<String> names = Lists.newArrayList(section.fieldNames());
-		Collections.sort(names, new Comparator<String>() {
-			@Override
-			public int compare(String s1, String s2) {
-				Matcher m1 = namePat.matcher(s1);
-				Matcher m2 = namePat.matcher(s2);
-				// if prefix matches case-insenstively, sort primarily by prefix,
-				// case-sensitively, then by suffix,
-				// numerically. This way, e.g. FOO_xxx names will not be intermingled with
-				// Foo_xxx names.
-				if (m1.matches() && m2.matches() && m1.group(1).equalsIgnoreCase(m2.group(1))) {
-					return ComparisonChain.start() //
-							.compare(m1.group(1), m2.group(1)) //
-							.compare(Integer.valueOf(m1.group(2)), Integer.valueOf(m2.group(2))) //
-							.result();
-				} else if (m1.matches() && !m2.matches() && m1.group(1).equalsIgnoreCase(s2)) {
-					// This case and the next ensure that Foo immediatly precedes Foo_xxx, and
-					// likewise FOO immediately
-					// precedes FOO_xxx
-					return m1.group(1).compareTo(s2);
-				} else if (!m1.matches() && m2.matches() && s1.equalsIgnoreCase(m2.group(1))) {
-					return s1.compareTo(m2.group(1));
-				} else
-					return String.CASE_INSENSITIVE_ORDER.compare(s1, s2);
-			}
-		});
+    private void sortSection(JsonNode section) {
+        List<String> names = Lists.newArrayList(section.fieldNames());
+        Collections.sort(names, new Comparator<String>() {
+            @Override
+            public int compare(String s1, String s2) {
+                Matcher m1 = namePat.matcher(s1);
+                Matcher m2 = namePat.matcher(s2);
+                // if prefix matches case-insenstively, sort primarily by prefix,
+                // case-sensitively, then by suffix,
+                // numerically. This way, e.g. FOO_xxx names will not be intermingled with
+                // Foo_xxx names.
+                if (m1.matches() && m2.matches() && m1.group(1).equalsIgnoreCase(m2.group(1))) {
+                    return ComparisonChain.start() //
+                            .compare(m1.group(1), m2.group(1)) //
+                            .compare(Integer.valueOf(m1.group(2)), Integer.valueOf(m2.group(2))) //
+                            .result();
+                } else if (m1.matches() && !m2.matches() && m1.group(1).equalsIgnoreCase(s2)) {
+                    // This case and the next ensure that Foo immediatly precedes Foo_xxx, and
+                    // likewise FOO immediately
+                    // precedes FOO_xxx
+                    return m1.group(1).compareTo(s2);
+                } else if (!m1.matches() && m2.matches() && s1.equalsIgnoreCase(m2.group(1))) {
+                    return s1.compareTo(m2.group(1));
+                } else
+                    return String.CASE_INSENSITIVE_ORDER.compare(s1, s2);
+            }
+        });
 
-		ObjectNode sectionObj = (ObjectNode) section;
-		for (String name : names) {
-			if (!isVendorExtension(name)) {
-				JsonNode obj = sectionObj.remove(name);
-				sectionObj.set(name, obj);
-			}
-		}
-	}
+        ObjectNode sectionObj = (ObjectNode) section;
+        for (String name : names) {
+            if (!isVendorExtension(name)) {
+                JsonNode obj = sectionObj.remove(name);
+                sectionObj.set(name, obj);
+            }
+        }
+    }
 
-	private void sortInPath(JsonNode path) {
-		ObjectNode pathObj = (ObjectNode) path;
-		for (String methodName : Util.swaggerMethodOrder) {
-			if (pathObj.has(methodName)) {
-				ObjectNode methodObj = (ObjectNode) pathObj.remove(methodName);
-				pathObj.set(methodName, methodObj);
-				sortResponsesInMethod(methodObj);
-			}
-		}
+    private void sortInPath(JsonNode path) {
+        ObjectNode pathObj = (ObjectNode) path;
+        for (String methodName : Util.swaggerMethodOrder) {
+            if (pathObj.has(methodName)) {
+                ObjectNode methodObj = (ObjectNode) pathObj.remove(methodName);
+                pathObj.set(methodName, methodObj);
+                sortResponsesInMethod(methodObj);
+            }
+        }
 
-	}
+    }
 
-	private Pattern numberPat = Pattern.compile("\\d+");
+    private Pattern numberPat = Pattern.compile("\\d+");
 
-	private void sortResponsesInMethod(ObjectNode method) {
-		ObjectNode responses = (ObjectNode) method.get("responses");
-		if (responses != null) {
-			List<String> names = Lists.newArrayList(responses.fieldNames());
-			// numeric responses first, followed by named responses
-			Collections.sort(names, new Comparator<String>() {
-				@Override
-				public int compare(String s1, String s2) {
-					if (numberPat.matcher(s1).matches()) {
-						if (numberPat.matcher(s2).matches()) {
-							return Integer.valueOf(s1) - Integer.valueOf(s2);
-						} else {
-							return -1;
-						}
-					} else if (numberPat.matcher(s2).matches()) {
-						return 1;
-					} else {
-						return String.CASE_INSENSITIVE_ORDER.compare(s1, s2);
-					}
-				}
-			});
-			for (String name : names) {
-				if (!isVendorExtension(name)) {
-					JsonNode obj = responses.remove(name);
-					responses.set(name, obj);
-				}
-			}
-		}
-	}
+    private void sortResponsesInMethod(ObjectNode method) {
+        ObjectNode responses = (ObjectNode) method.get("responses");
+        if (responses != null) {
+            List<String> names = Lists.newArrayList(responses.fieldNames());
+            // numeric responses first, followed by named responses
+            Collections.sort(names, new Comparator<String>() {
+                @Override
+                public int compare(String s1, String s2) {
+                    if (numberPat.matcher(s1).matches()) {
+                        if (numberPat.matcher(s2).matches()) {
+                            return Integer.valueOf(s1) - Integer.valueOf(s2);
+                        } else {
+                            return -1;
+                        }
+                    } else if (numberPat.matcher(s2).matches()) {
+                        return 1;
+                    } else {
+                        return String.CASE_INSENSITIVE_ORDER.compare(s1, s2);
+                    }
+                }
+            });
+            for (String name : names) {
+                if (!isVendorExtension(name)) {
+                    JsonNode obj = responses.remove(name);
+                    responses.set(name, obj);
+                }
+            }
+        }
+    }
 
-	private void markPositions(ObjectNode tree) {
-		for (ObjectType sectionType : ObjectType.getTypesForVersion(modelVersion)) {
-			JsonNode section = sectionType.getFromNode(tree, modelVersion);
-			if (section != null) {
-				markPositionsInSection(section);
-				if (sectionType == ObjectType.PATH) {
-					for (Entry<String, JsonNode> path : Util.iterable(section.fields())) {
-						markPositionsInPath(path.getValue());
-					}
-				}
-			}
-		}
-	}
+    private void markPositions(ObjectNode tree) {
+        for (ObjectType sectionType : ObjectType.getTypesForVersion(modelVersion)) {
+            JsonNode section = sectionType.getFromNode(tree, modelVersion);
+            if (section != null) {
+                markPositionsInSection(section);
+                if (sectionType == ObjectType.PATH) {
+                    for (Entry<String, JsonNode> path : Util.iterable(section.fields())) {
+                        markPositionsInPath(path.getValue());
+                    }
+                }
+            }
+        }
+    }
 
-	private void markPositionsInSection(JsonNode section) {
-		int position = 0;
-		for (Entry<String, JsonNode> field : Util.iterable(section.fields())) {
-			if (!isVendorExtension(field.getKey())) {
-				OpenApiMarkers.markPosition(field.getValue(), position++);
-			}
-		}
-	}
+    private void markPositionsInSection(JsonNode section) {
+        int position = 0;
+        for (Entry<String, JsonNode> field : Util.iterable(section.fields())) {
+            if (!isVendorExtension(field.getKey())) {
+                OpenApiMarkers.markPosition(field.getValue(), position++);
+            }
+        }
+    }
 
-	private void markPositionsInPath(JsonNode path) {
-		int position = 0;
-		for (Entry<String, JsonNode> method : Util.iterable(path.fields())) {
-			if (!isVendorExtension(method.getKey())) {
-				OpenApiMarkers.markPosition(method.getValue(), position++);
-				JsonNode responses = method.getValue().get("responses");
-				if (responses != null) {
-					int respPosition = 0;
-					for (Entry<String, JsonNode> response : Util.iterable(responses.fields())) {
-						if (!isVendorExtension(response.getKey())) {
-							OpenApiMarkers.markPosition(response.getValue(), respPosition++);
-						}
-					}
-				}
-			}
-		}
-	}
+    private void markPositionsInPath(JsonNode path) {
+        int position = 0;
+        for (Entry<String, JsonNode> method : Util.iterable(path.fields())) {
+            if (!isVendorExtension(method.getKey())) {
+                OpenApiMarkers.markPosition(method.getValue(), position++);
+                JsonNode responses = method.getValue().get("responses");
+                if (responses != null) {
+                    int respPosition = 0;
+                    for (Entry<String, JsonNode> response : Util.iterable(responses.fields())) {
+                        if (!isVendorExtension(response.getKey())) {
+                            OpenApiMarkers.markPosition(response.getValue(), respPosition++);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	/**
-	 * Peform inline processing on a single top-level model object in the final
-	 * constructed spec.
-	 */
-	private JsonNode inline(JsonNode tree, Reference ref) {
-		try (Visit v = refVisitor.visit(ref)) {
-			return maybeInline(tree, ref);
-		} catch (VisitRecursionException e) {
-			// this exception is actually impossible here, since this method is invoked only
-			// for top-level swagger
-			// objects in the final constructed specs. Thus, on entry, the "visited refs"
-			// list in RefVisitor class must
-			// be empty. Of course, Java compiler can't figure that out so we need to do
-			// something here.
-			return tree;
-		}
-	}
+    /**
+     * Peform inline processing on a single top-level model object in the final constructed spec.
+     */
+    private JsonNode inline(JsonNode tree, Reference ref) {
+        try (Visit v = refVisitor.visit(ref)) {
+            return maybeInline(tree, ref);
+        } catch (VisitRecursionException e) {
+            // this exception is actually impossible here, since this method is invoked only
+            // for top-level swagger
+            // objects in the final constructed specs. Thus, on entry, the "visited refs"
+            // list in RefVisitor class must
+            // be empty. Of course, Java compiler can't figure that out so we need to do
+            // something here.
+            return tree;
+        }
+    }
 
-	/**
-	 * Main workhorse of this class.
-	 * <p>
-	 * This method recursively visits the entire tree in a depth-first manner,
-	 * processing every reference node encountered, in one of the four manners
-	 * described in the class javadoc. The depth-first strategy applies to inlined
-	 * content, which is processed immediately after insertion into the tree, before
-	 * continuing with whatever node would otherwise have followed the replaced ref
-	 * node.
-	 */
-	private JsonNode maybeInline(JsonNode node, Reference base) {
-		if (Util.isRef(node)) {
-			Reference ref = new Reference(Util.getRefString(node).get(), base, modelVersion);
-			if (ref.isModelObjectRef()) {
-				ObjectType section = ref.getSection();
-				if (options.isInlined(section)) {
-					// try to inline
-					Optional<JsonNode> replacement = contentManager.getModelObject(ref);
-					if (replacement.isPresent()) {
-						// guard against recursion
-						try (Visit v = refVisitor.visit(ref)) {
-							// good replacement, non-recursive... perform the reference
-							JsonNode result = maybeInline(Util.safeDeepCopy(replacement.get()), ref);
-							addRefFileUrls(result, ref);
-							if (ref.isDefinitionRef()) {
-								// schemas turn into embedded objects and therefore lose their "definition"
-								// names - we
-								// mark them with a vendor extension for use in generated documentation
-								OpenApiMarkers.markTypeName(result, ref.getObjectName());
-							}
-							return result;
-						} catch (VisitRecursionException e) {
-							// this was a recursive reference - localize instead
-							return contentManager.getLocalizedRefNode(ref);
-						}
-					} else {
-						// could not obtain replacement tree from reference
-						return ref.getBadRefNode();
-					}
-				} else {
-					// !inline => localize
-					return contentManager.getLocalizedRefNode(ref);
-				}
-			}
-			// a ref, but not a model object ref - we shouldn't have those following
-			// assembly by ContentManager
-			return ref.getBadRefNode();
+    /**
+     * Main workhorse of this class.
+     * <p>
+     * This method recursively visits the entire tree in a depth-first manner, processing every reference node
+     * encountered, in one of the four manners described in the class javadoc. The depth-first strategy applies to
+     * inlined content, which is processed immediately after insertion into the tree, before continuing with whatever
+     * node would otherwise have followed the replaced ref node.
+     */
+    private JsonNode maybeInline(JsonNode node, Reference base) {
+        if (Util.isRef(node)) {
+            Reference ref = new Reference(Util.getRefString(node).get(), base, modelVersion);
+            if (ref.isModelObjectRef()) {
+                ObjectType section = ref.getSection();
+                if (options.isInlined(section)) {
+                    // try to inline
+                    Optional<JsonNode> replacement = contentManager.getModelObject(ref);
+                    if (replacement.isPresent()) {
+                        // guard against recursion
+                        try (Visit v = refVisitor.visit(ref)) {
+                            // good replacement, non-recursive... perform the reference
+                            JsonNode result = maybeInline(Util.safeDeepCopy(replacement.get()), ref);
+                            addRefFileUrls(result, ref);
+                            if (ref.isDefinitionRef()) {
+                                // schemas turn into embedded objects and therefore lose their "definition"
+                                // names - we
+                                // mark them with a vendor extension for use in generated documentation
+                                OpenApiMarkers.markTypeName(result, ref.getObjectName());
+                            }
+                            return result;
+                        } catch (VisitRecursionException e) {
+                            // this was a recursive reference - localize instead
+                            return contentManager.getLocalizedRefNode(ref);
+                        }
+                    } else {
+                        // could not obtain replacement tree from reference
+                        return ref.getBadRefNode();
+                    }
+                } else {
+                    // !inline => localize
+                    return contentManager.getLocalizedRefNode(ref);
+                }
+            }
+            // a ref, but not a model object ref - we shouldn't have those following
+            // assembly by ContentManager
+            return ref.getBadRefNode();
 
-		} else {
-			// not a reference node - search contained structures for embedded refs
-			maybeInlineObjectFields(node, base);
-			maybeInlineArrayElements(node, base);
-			return node;
-		}
-	}
+        } else {
+            // not a reference node - search contained structures for embedded refs
+            maybeInlineObjectFields(node, base);
+            maybeInlineArrayElements(node, base);
+            return node;
+        }
+    }
 
-	private void maybeInlineObjectFields(JsonNode node, Reference base) {
-		if (node instanceof ObjectNode) {
-			ObjectNode objNode = (ObjectNode) node;
-			for (Entry<String, JsonNode> field : Util.iterable(objNode.fields())) {
-				field.setValue(maybeInline(field.getValue(), base));
-			}
-		}
-	}
+    private void maybeInlineObjectFields(JsonNode node, Reference base) {
+        if (node instanceof ObjectNode) {
+            ObjectNode objNode = (ObjectNode) node;
+            for (Entry<String, JsonNode> field : Util.iterable(objNode.fields())) {
+                field.setValue(maybeInline(field.getValue(), base));
+            }
+        }
+    }
 
-	private void maybeInlineArrayElements(JsonNode node, Reference base) {
-		if (node instanceof ArrayNode) {
-			ArrayNode arrayNode = (ArrayNode) node;
-			for (int i = 0; i < arrayNode.size(); i++) {
-				arrayNode.set(i, maybeInline(arrayNode.get(i), base));
-			}
-		}
-	}
+    private void maybeInlineArrayElements(JsonNode node, Reference base) {
+        if (node instanceof ArrayNode) {
+            ArrayNode arrayNode = (ArrayNode) node;
+            for (int i = 0; i < arrayNode.size(); i++) {
+                arrayNode.set(i, maybeInline(arrayNode.get(i), base));
+            }
+        }
+    }
 
-	private boolean isVendorExtension(String propName) {
-		return propName.startsWith("x-");
-	}
+    private boolean isVendorExtension(String propName) {
+        return propName.startsWith("x-");
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@ ModelSolv, Inc. - initial API and implementation and/or initial documentation --
         <profile>
             <id>releases</id>
             <build>
-                <plugins />
+                <plugins/>
             </build>
         </profile>
     </profiles>


### PR DESCRIPTION
This is an initial and limited implementation of something that was
missing from the design of the normalizer. Namely, may be required for
completeness in a model without having any reference nodes referring to
them. An example is showing up in the beamup example now that we're
using a KZOP version with more complete validations. The model contains
a security scheme that must be retained because its name appears in a
security requirement in the model.

This implementation fixes the live doc view for the beamup example, but
is incomplete in two ways:
1. There are other implicit retention requirements that are not
   implemented, e.g for callbacks and links
2. Top-level security requirements (i.e. not cotnained in an operation
   object) are not processed.