### PR TITLE
ZEN-4602 Make gentemplate prereqs required by default

### DIFF
--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/template/builders/PrerequisiteBuilder.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/template/builders/PrerequisiteBuilder.java
@@ -14,7 +14,7 @@ import com.reprezen.genflow.api.template.IGenTemplate;
 public class PrerequisiteBuilder extends NamedBuilderBase<PrerequisiteBuilder> {
 
 	private String genTemplateId;
-	private boolean required;
+	private boolean required = true;
 
 	public PrerequisiteBuilder on(String genTemplateId) {
 		this.genTemplateId = genTemplateId;

--- a/pom.xml
+++ b/pom.xml
@@ -197,12 +197,6 @@ ModelSolv, Inc. - initial API and implementation and/or initial documentation --
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>releases</id>
-            <build>
-                <plugins />
-            </build>
-        </profile>
     </profiles>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This is a more natural default, and it will actually fix, en-masse, any
of our reprezen-provider gentemplates that have rereqs. They are all, in
fact, required, but at least some are not declared as required, so
they're effectively optional. This will make them effectively required.