### PR TITLE
[ZEN-4575] Several false negatives in content assist tests

### DIFF
--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/zenmodel/util/CommonServices.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/zenmodel/util/CommonServices.java
@@ -8,9 +8,6 @@
  *******************************************************************************/
 package com.reprezen.genflow.api.zenmodel.util;
 
-import static com.reprezen.rapidml.xtext.loaders.ZenLibraries.PRIMITIVE_TYPES;
-
-import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -38,7 +35,6 @@ import com.reprezen.rapidml.ZenModel;
 import com.reprezen.rapidml.datatypes.cardinality.Cardinality;
 import com.reprezen.rapidml.datatypes.cardinality.FeatureCardinalities;
 import com.reprezen.rapidml.datatypes.cardinality.OverrideCardinalities;
-import com.reprezen.rapidml.xtext.loaders.ModelLoaderUtils;
 import com.reprezen.rapidml.xtext.util.ZenModelHelper;
 
 /**
@@ -48,7 +44,6 @@ import com.reprezen.rapidml.xtext.util.ZenModelHelper;
  * @since 2013/05/29
  */
 public class CommonServices {
-	private ZenModel zenModel;
 
 	public CommonServices() {
 	}
@@ -97,13 +92,6 @@ public class CommonServices {
 					.getCardinality(includedProperty.getBaseProperty());
 		}
 		return cardinality.getLabel();
-	}
-
-	protected ZenModel getAndLoadZenModel() throws IOException {
-		if (this.zenModel == null) {
-			this.zenModel = ModelLoaderUtils.loadModel(PRIMITIVE_TYPES);
-		}
-		return this.zenModel;
 	}
 
 	/**


### PR DESCRIPTION
Remove call to RapidML ModelLoaderUtils that now uses a different API. The method is completly removed since it is not used anywhere.