### PR TITLE
Define 'snap' profile allow snapshot dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,19 @@
                 </plugins>
             </build>
         </profile>
-    </profiles>
+		<profile>
+			<id>snap</id>
+			<repositories>
+				<repository>
+					<id>sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+					<layout>default</layout>
+					<releases><enabled>false</enabled></releases>
+					<snapshots><enabled>true</enabled></snapshots>
+				</repository>
+			</repositories>
+		</profile>
+	</profiles>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
The profile adds the sonatype snapshot repo into the mix, so test builds
can be created with snapshot dependencies