### PR TITLE
Add dependencies for commons-text

### DIFF
--- a/modules/gentemplates/common/pom.xml
+++ b/modules/gentemplates/common/pom.xml
@@ -72,6 +72,10 @@
             <groupId>com.atlassian.commonmark</groupId>
             <artifactId>commonmark-ext-autolink</artifactId>
         </dependency>
+        <dependency>
+        	<groupId>org.apache.commons</groupId>
+        	<artifactId>commons-text</artifactId>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/modules/gentemplates/swagger-doc/pom.xml
+++ b/modules/gentemplates/swagger-doc/pom.xml
@@ -23,5 +23,9 @@
             <groupId>com.reprezen.genflow</groupId>
             <artifactId>genflow-common</artifactId>
         </dependency>
+        <dependency>
+        	<groupId>org.apache.commons</groupId>
+        	<artifactId>commons-text</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
It's a mystery why prior versions were able to compile. A class in
genflow-common imported and used a class from apache's commons-text
library, but it was not required in the pom.xml and was not transitively
included. The swagger-doc gentemplate project had the same problem.

Adding the dependnecy to genflow-common fixed both projects (since
swagger-doc picked it upt transitively), but I've added it to both for
hygiene.