### PR TITLE
ZEN-4408 Fix logic in SCG/OAG module discovery

### DIFF
--- a/modules/gentemplates/openapi-generator/src/main/java/com/reprezen/genflow/openapi/generator/OpenApiGeneratorGenTemplateGroup.java
+++ b/modules/gentemplates/openapi-generator/src/main/java/com/reprezen/genflow/openapi/generator/OpenApiGeneratorGenTemplateGroup.java
@@ -39,7 +39,9 @@ public class OpenApiGeneratorGenTemplateGroup implements IGenTemplateGroup {
 		for (Class<? extends CodegenConfig> config : getCodegenConfigClasses(modulesInfo,
 				CodegenConfig.class.getClassLoader())) {
 			Info info = modulesInfo.getInfo(config);
-			genTemplates.add(new BuiltinOpenApiGeneratorGenTemplate(config, info));
+			if (info != null && !info.isSuppressed()) {
+				genTemplates.add(new BuiltinOpenApiGeneratorGenTemplate(config, info));
+			}
 		}
 		return genTemplates;
 	}
@@ -52,13 +54,7 @@ public class OpenApiGeneratorGenTemplateGroup implements IGenTemplateGroup {
 			while (urls.hasMoreElements()) {
 				URL url = urls.nextElement();
 				for (Class<? extends CodegenConfig> candidate : getClassesFromServiceLoaderResource(url, classLoader)) {
-					Info info = modulesInfo.getInfo(candidate);
-					// we only provide built-in SCG modules, for which we must have moduleinfo
-					// discovered during product
-					// build
-					if (info == null || !info.isSuppressed()) {
-						classes.add(candidate);
-					}
+					classes.add(candidate);
 				}
 			}
 		} catch (IOException e) {

--- a/modules/gentemplates/swagger-codegen/src/main/java/com/reprezen/genflow/swagger/codegen/SwaggerCodegenGenTemplateGroup.java
+++ b/modules/gentemplates/swagger-codegen/src/main/java/com/reprezen/genflow/swagger/codegen/SwaggerCodegenGenTemplateGroup.java
@@ -40,9 +40,11 @@ public class SwaggerCodegenGenTemplateGroup implements IGenTemplateGroup {
 		for (Class<? extends CodegenConfig> config : getCodegenConfigClasses(modulesInfo,
 				CodegenConfig.class.getClassLoader())) {
 			Info info = modulesInfo.getInfo(config);
-			BuiltinSwaggerCodegenGenTemplate builtinSwaggerCodegenGenTemplate = new BuiltinSwaggerCodegenGenTemplate(
-					config, info);
-			genTemplates.add(builtinSwaggerCodegenGenTemplate);
+			if (info != null && !info.isSuppressed()) {
+				BuiltinSwaggerCodegenGenTemplate builtinSwaggerCodegenGenTemplate = new BuiltinSwaggerCodegenGenTemplate(
+						config, info);
+				genTemplates.add(builtinSwaggerCodegenGenTemplate);
+			}
 		}
 		return genTemplates;
 	}
@@ -55,13 +57,7 @@ public class SwaggerCodegenGenTemplateGroup implements IGenTemplateGroup {
 			while (urls.hasMoreElements()) {
 				URL url = urls.nextElement();
 				for (Class<? extends CodegenConfig> candidate : getClassesFromServiceLoaderResource(url, classLoader)) {
-					Info info = modulesInfo.getInfo(candidate);
-					// we only provide built-in SCG modules, for which we must have moduleinfo
-					// discovered during product
-					// build
-					if (info == null || !info.isSuppressed()) {
-						classes.add(candidate);
-					}
+					classes.add(candidate);
 				}
 			}
 		} catch (IOException e) {


### PR DESCRIPTION
Formerly, the SCG and OAG wrappers attempted to create gentemplates from
SCG/OAG modules for which module info was not available. That didn't
result in NPEs only because we were using fixed SCG/OAG versions for
which we had performed discovery.

Now, API Studio will use version ranges for SCG/OAG gentemplates, so we
may now end up scanning modules for which we have no info.

For now we will permit use only of known modules (modules with module
info already recorded and vetted), and the logic has been adjusted
accordingly.