### PR TITLE
ZEN-3094 Report SCG/OAG versions on execution

### DIFF
--- a/modules/genflow-api/src/main/java/com/reprezen/genflow/api/util/GeneratorLauncher.java
+++ b/modules/genflow-api/src/main/java/com/reprezen/genflow/api/util/GeneratorLauncher.java
@@ -207,7 +207,15 @@ public class GeneratorLauncher {
 				}
 			}
 		};
-		Handler handler = new StreamHandler(System.out, formatter);
+		Handler handler = new StreamHandler(System.out, formatter) {
+
+			@Override
+			public synchronized void publish(LogRecord record) {
+				super.publish(record);
+				flush();
+			}
+
+		};
 		logger.addHandler(handler);
 		logger.setUseParentHandlers(false);
 		return logger;

--- a/modules/gentemplates/openapi-generator/src/main/java/com/reprezen/genflow/openapi/generator/OagCodegenGenTemplateBase.java
+++ b/modules/gentemplates/openapi-generator/src/main/java/com/reprezen/genflow/openapi/generator/OagCodegenGenTemplateBase.java
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package com.reprezen.genflow.openapi.generator;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -126,10 +125,8 @@ public abstract class OagCodegenGenTemplateBase extends OpenApiGenTemplate {
 					.get(OPENAPI_CODEGEN_SYSTEM_PROPERTIES);
 			setSystemProperties(systemProperties);
 			generator.opts(clientOptInput);
-			List<File> result = generator.generate();
-			for (File next : result) {
-				System.out.println("File: " + next.getAbsolutePath());
-			}
+			reportOagVersion();
+			generator.generate();
 		}
 
 		private void addParameters(Map<String, String> config, Map<String, Object> params) {
@@ -151,5 +148,9 @@ public abstract class OagCodegenGenTemplateBase extends OpenApiGenTemplate {
 			}
 		}
 
+		private void reportOagVersion() {
+			context.getLogger().info(String.format("Using openapi-generator v%s\n",
+					CodegenConfig.class.getPackage().getImplementationVersion()));
+		}
 	}
 }

--- a/modules/gentemplates/swagger-codegen/src/main/java/com/reprezen/genflow/swagger/codegen/ScgCodegenGenTemplateBase.java
+++ b/modules/gentemplates/swagger-codegen/src/main/java/com/reprezen/genflow/swagger/codegen/ScgCodegenGenTemplateBase.java
@@ -120,6 +120,7 @@ public abstract class ScgCodegenGenTemplateBase extends SwaggerGenTemplate {
 					.get(SWAGGER_CODEGEN_SYSTEM_PROPERTIES);
 			setSystemProperties(systemProperties);
 			generator.opts(clientOptInput);
+			reportScgVersion();
 			generator.generate();
 		}
 
@@ -140,6 +141,11 @@ public abstract class ScgCodegenGenTemplateBase extends SwaggerGenTemplate {
 					System.setProperty(key, properties.get(key));
 				}
 			}
+		}
+
+		private void reportScgVersion() {
+			context.getLogger().info(String.format("Using swagger-codegen v%s\n",
+					CodegenConfig.class.getPackage().getImplementationVersion()));
 		}
 	}
 }


### PR DESCRIPTION
The SCG and OAG wrappers now report the SCG/OAG library versions when
executing gentemplates.

Also fixed an issue with bad synchronization between output to stdout by
the SCG/OAG modules, and output from the gentarget logger. The latter
was buffering, so e.g., the "Executing GenTarget Xxx" message would
come *after* all the output produced by the Xxx module.

The logger is now configured to flush after every log record.