### PR TITLE
ZEN-4734 - Correct Travis config for Maven Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: java
 cache:
   directories:
     - $HOME/.m2
+# Adding a comment to check travis build time. 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
-pcache:
+cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Fixes ZEN-4734
https://modelsolv.atlassian.net/browse/ZEN-4734

I noticed that the Travis CI build spends some time at the beginning rebuilding the Maven cache. The Travis docs here describe how you can use the `cache` object in `.travis.yml` to cache the `.m2` directory across builds.
https://docs.travis-ci.com/user/caching/

We have this configured, but the key was named `pcache` instead of `cache`.
https://github.com/RepreZen/GenFlow/blob/master/.travis.yml