### PR TITLE
[ZEN-4720] Normalizer: Retain PATH_OR_COMPONENT throws exception

### DIFF
--- a/modules/genflow-api/pom.xml
+++ b/modules/genflow-api/pom.xml
@@ -155,7 +155,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/modules/genflow-tests/pom.xml
+++ b/modules/genflow-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>genflow-tests</artifactId>

--- a/modules/gentemplates/common/pom.xml
+++ b/modules/gentemplates/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>genflow-common</name>

--- a/modules/gentemplates/openapi-diagram/pom.xml
+++ b/modules/gentemplates/openapi-diagram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
     <artifactId>openapi-diagram</artifactId>

--- a/modules/gentemplates/openapi-generator/pom.xml
+++ b/modules/gentemplates/openapi-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>openapi-generator</artifactId>

--- a/modules/gentemplates/openapi-normalizer/pom.xml
+++ b/modules/gentemplates/openapi-normalizer/pom.xml
@@ -19,5 +19,9 @@
             <groupId>com.reprezen.genflow</groupId>
             <artifactId>genflow-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/gentemplates/openapi-normalizer/pom.xml
+++ b/modules/gentemplates/openapi-normalizer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>openapi-normalizer</artifactId>

--- a/modules/gentemplates/openapi-normalizer/src/main/java/com/reprezen/genflow/openapi/normalizer/NormalizerParameters.java
+++ b/modules/gentemplates/openapi-normalizer/src/main/java/com/reprezen/genflow/openapi/normalizer/NormalizerParameters.java
@@ -107,6 +107,7 @@ public class NormalizerParameters {
 	static {
 		specialRetainTypes.put("ALL", Option.ALL_OBJECTS);
 		specialRetainTypes.put("COMPONENTS", Option.COMPONENT_OBJECTS);
+		specialRetainTypes.put("PATH_OR_COMPONENTS", Option.PATH_OR_COMPONENTS);
 	}
 
 	private Set<ObjectType> getRetainData(Object data) throws BadParameterException {

--- a/modules/gentemplates/openapi-normalizer/src/main/java/com/reprezen/genflow/openapi/normalizer/NormalizerParameters.java
+++ b/modules/gentemplates/openapi-normalizer/src/main/java/com/reprezen/genflow/openapi/normalizer/NormalizerParameters.java
@@ -92,7 +92,7 @@ public class NormalizerParameters {
 		}
 	}
 
-	private static Map<String, Collection<ObjectType>> specialInlineTypes = Maps.newHashMap();
+	private static Map<String, Set<ObjectType>> specialInlineTypes = Maps.newHashMap();
 	static {
 		specialInlineTypes.put("ALL", Option.ALL_OBJECTS);
 		specialInlineTypes.put("COMPONENTS", Option.COMPONENT_OBJECTS);
@@ -103,7 +103,7 @@ public class NormalizerParameters {
 		return getEnumListData(data, ObjectType.class, specialInlineTypes);
 	}
 
-	private static Map<String, Collection<ObjectType>> specialRetainTypes = Maps.newHashMap();
+	private static Map<String, Set<ObjectType>> specialRetainTypes = Maps.newHashMap();
 	static {
 		specialRetainTypes.put("ALL", Option.ALL_OBJECTS);
 		specialRetainTypes.put("COMPONENTS", Option.COMPONENT_OBJECTS);
@@ -118,7 +118,7 @@ public class NormalizerParameters {
 		return getEnumData(data, RetentionScopeType.class);
 	}
 
-	private static Map<String, Collection<HoistType>> specialHoistTypes = Maps.newHashMap();
+	private static Map<String, Set<HoistType>> specialHoistTypes = Maps.newHashMap();
 	static {
 		specialHoistTypes.put("ALL", Option.ALL_HOIST_TYPES);
 		specialHoistTypes.put("NONE", Option.NO_HOIST_TYPES);
@@ -132,7 +132,7 @@ public class NormalizerParameters {
 		return getEnumData(data, OrderingScheme.class);
 	}
 
-	private static Map<String, Collection<ExtensionData>> specialExtensionRetentionTypes = Maps.newHashMap();
+	private static Map<String, Set<ExtensionData>> specialExtensionRetentionTypes = Maps.newHashMap();
 	static {
 		specialExtensionRetentionTypes.put("ALL", Option.ALL_EXTENSION_DATA);
 		specialExtensionRetentionTypes.put("NONE", Option.NO_EXTENSION_DATA);
@@ -142,7 +142,7 @@ public class NormalizerParameters {
 		return getEnumListData(data, ExtensionData.class, specialExtensionRetentionTypes);
 	}
 
-	private <T extends Enum<T>> Set<T> getEnumListData(Object data, Class<T> cls, Map<String, Collection<T>> specials)
+	private <T extends Enum<T>> Set<T> getEnumListData(Object data, Class<T> cls, Map<String, Set<T>> specials)
 			throws BadParameterException {
 		Set<T> results = Sets.newHashSet();
 		if (data instanceof Collection<?>) {
@@ -153,7 +153,10 @@ public class NormalizerParameters {
 		} else if (data instanceof String) {
 			String string = (String) data;
 			if (specials != null && specials.containsKey(string)) {
-				results.addAll(specials.get(string));
+				// we return the value instead of copying it
+				// as we want to test for object equality
+				// see method Options.isRetained(objectType, hasPaths)
+				results = specials.get(string);
 			} else {
 				results.add(getEnumData(data, cls));
 			}

--- a/modules/gentemplates/openapi-normalizer/src/main/java/com/reprezen/genflow/openapi/normalizer/OpenApiNormalizerGenTemplate.java
+++ b/modules/gentemplates/openapi-normalizer/src/main/java/com/reprezen/genflow/openapi/normalizer/OpenApiNormalizerGenTemplate.java
@@ -63,13 +63,13 @@ public class OpenApiNormalizerGenTemplate extends OpenApiGenTemplate {
 				"REQUEST_BODY, HEADER, SECURITY_SCHEME, LINK, and CALLBACK.",
 				"In both cases, ALL means all of those; COMPONENTS means all but PATH; NONE means none of them.",
 				"Note that recursive objects cannot be fully inlined. Each explicit reference to such an",
-				"object will be inlined, but recursive references encocuntered during that inlining will be",
+				"object will be inlined, but recursive references encountered during that inlining will be",
 				"retained as references, forcing the object to be retained in the normalized model.")
 				.withDefault(Arrays.asList(ObjectType.PARAMETER, ObjectType.RESPONSE)));
 		define(parameter().named(OptionType.RETAIN.name())
 				.withDescription("List of model object types to retain. Allowed values are same as for INLINE.",
 						"As for INLINE, ALL means all types, and COMPONENTS means all but PATH.",
-						"PATH_OR_COMPONENT means PATH if the model has any paths, and COMPONENTS otherwise.",
+						"PATH_OR_COMPONENTS means PATH if the model has any paths, and COMPONENTS otherwise.",
 						"Note that any object for which there is a non-inlined reference will be retained regardless",
 						"of this setting. If you see retained objects that you didn't expect, you may have to adjust",
 						"your INLINE setting.")

--- a/modules/gentemplates/openapi-normalizer/src/test/java/com/reprezen/genflow/openapi/normalizer/GenTemplateTest.xtend
+++ b/modules/gentemplates/openapi-normalizer/src/test/java/com/reprezen/genflow/openapi/normalizer/GenTemplateTest.xtend
@@ -1,0 +1,27 @@
+package com.reprezen.genflow.openapi.normalizer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.io.Resources
+import com.reprezen.genflow.api.target.GenTargetUtils
+import java.io.File
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+class GenTemplateTest {
+
+	@Test
+	def void testGenTemplate() {
+		val gt = GenTargetUtils.load(
+			new File(Resources.getResource(GenTemplateTest, "/normalizer_path_or_components.gen").toURI))
+
+		val traces = gt.execute
+		val output = new File(new File(traces.baseDirectory, "generated"), "Swagger Petstore.json")
+		
+		val tree = new ObjectMapper().readTree(output)
+
+		assertFalse(tree.get("paths").isEmpty)
+		assertFalse(tree.get("components").isEmpty)
+	}
+
+}

--- a/modules/gentemplates/openapi-normalizer/src/test/java/com/reprezen/genflow/openapi/normalizer/NormalizerParametersTest.xtend
+++ b/modules/gentemplates/openapi-normalizer/src/test/java/com/reprezen/genflow/openapi/normalizer/NormalizerParametersTest.xtend
@@ -1,0 +1,64 @@
+package com.reprezen.genflow.openapi.normalizer
+
+import com.reprezen.genflow.api.normal.openapi.Option
+import java.util.Map
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+class NormalizerParametersTest {
+	
+	@Test
+	def void testRetain_All() {
+		val Map<String, Object> parameters = #{"RETAIN" -> "ALL"}
+
+		val params = new NormalizerParameters(parameters)
+
+		// Contains options RETAIN and DEFER_EXTENSION_DATA_REMOVAL
+		assertEquals(2, params.options.size)
+
+		val option = params.options.get(0)
+		assertEquals(Option.RETAIN_ALL.data, option.data)
+	}
+
+	@Test
+	def void testRetain_Components() {
+		val Map<String, Object> parameters = #{"RETAIN" -> "COMPONENTS"}
+
+		val params = new NormalizerParameters(parameters)
+
+		// Contains options RETAIN and DEFER_EXTENSION_DATA_REMOVAL
+		assertEquals(2, params.options.size)
+
+		val option = params.options.get(0)
+		assertEquals(Option.RETAIN_COMPONENTS.data, option.data)
+	}
+
+	@Test
+	def void testRetain_Paths() {
+		val Map<String, Object> parameters = #{"RETAIN" -> "PATH"}
+
+		val params = new NormalizerParameters(parameters)
+
+		// Contains options RETAIN and DEFER_EXTENSION_DATA_REMOVAL
+		assertEquals(2, params.options.size)
+
+		val option = params.options.get(0)
+		// Expected value should be put in a collection here to pass test
+		// as NormalizerParameters always puts option data in collections
+		assertEquals(#{(Option.RETAIN_PATHS.data)}, option.data)
+	}
+
+	@Test
+	def void testRetain_PathOrComponent() {
+		val Map<String, Object> parameters = #{"RETAIN" -> "PATH_OR_COMPONENTS"}
+
+		val params = new NormalizerParameters(parameters)
+
+		// Contains options RETAIN and DEFER_EXTENSION_DATA_REMOVAL
+		assertEquals(2, params.options.size)
+
+		val option = params.options.get(0)
+		assertEquals(Option.RETAIN_PATHS_OR_COMPONENTS.data, option.data)
+	}
+}

--- a/modules/gentemplates/openapi-normalizer/src/test/resources/normalizer_path_or_components.gen
+++ b/modules/gentemplates/openapi-normalizer/src/test/resources/normalizer_path_or_components.gen
@@ -1,0 +1,88 @@
+---
+name: "KaiZen OpenAPI Normalizer [YAML+JSON]"
+genTemplateId: "com.reprezen.genflow.openapi.normalizer.OpenApiNormalizerGenTemplate"
+relativeOutputDir: generated
+prerequisites: null
+primarySource: 
+  path: "petstore.yaml"
+namedSources: null 
+# The parameters object contains variables that are processed directly by the GenTemplate.
+parameters: 
+  # List of model object types to inline.
+  # For v2 models, allowed values are PATH, DEFINITION, PARAMETER, and RESPONSE.
+  # For v3 models, allowed values are PATH, SCHEMA, RESPONSE, PARAMETER, EXAMPLE,
+  # REQUEST_BODY, HEADER, SECURITY_SCHEME, LINK, and CALLBACK.
+  # In both cases, ALL means all of those; COMPONENTS means all but PATH; NONE means none of them.
+  # Note that recursive objects cannot be fully inlined. Each explicit reference to such an
+  # object will be inlined, but recursive references encocuntered during that inlining will be
+  # retained as references, forcing the object to be retained in the normalized model.
+  INLINE: #
+    - "PARAMETER"
+    - "RESPONSE"
+  
+  # List of model object types to retain. Allowed values are same as for INLINE.
+  # As for INLINE, ALL means all types, and COMPONENTS means all but PATH.
+  # PATH_OR_COMPONENT means PATH if the model has any paths, and COMPONENTS otherwise.
+  # Note that any object for which there is a non-inlined reference will be retained regardless
+  # of this setting. If you see retained objects that you didn't expect, you may have to adjust
+  # your INLINE setting.
+  RETAIN: "PATH_OR_COMPONENTS"
+  
+  # Files whose unreferenced objects are eligible for retention
+  # ROOTS means the top-level file and files specified in ADDITIONAL_FILES.
+  # ALL means ROOTS plus any file that is loaded to resolve references.
+  RETENTION_SCOPE: "ALL"
+  
+  # List of additional files to be treated as top-level.
+  # Each file is specifed as a URL; relative URLs are resolved relative to
+  # the primary source model (NOT this GenTarget configuration file).
+  ADDITIONAL_FILES: #
+    []
+  
+  # List of hoisting operations to perform, including MEDIA_TYPE, PARAMETER, and SECURITY_REQUIREMENT.
+  # ALL means all of the above; NONE means none of them.
+  # This option applies only to v2 models
+  HOIST: "ALL"
+  
+  # Rewrite 'simple refs' to full refs. E.g. '$ref: Pet' => '$ref: "#/definitions/Pet"'
+  # This option applies only to v2 models.
+  REWRITE_SIMPLE_REFS: true
+  
+  # Copy schema definition name to title for definitions without titles
+  CREATE_DEF_TITLES: true
+  
+  # Replace null lists and maps with empty ones
+  #  This option applies only to v2 models.
+  INSTANTIATE_NULL_COLLECTIONS: true
+  
+  # Fill in missing 'object' types
+  # This option applies only to v2 models.
+  FIX_MISSING_TYPES: true
+  
+  # Write JSON Pointers as RepreZen vendor extension properties
+  ADD_JSON_POINTERS: true
+  
+  # How objects should be ordered in normalized model
+  # AS_DECLARED means leave things as they are in the source model
+  # SORTED means sort obects mostly alphabetically by name; see documentation for full details
+  # Note: ordering is currently enforced only for the root-level file
+  ORDERING: "SORTED"
+  
+  # Which aspects of the x-reprezen-normalization extension properties to retain in the generated spec. Choose from:
+  # - ORDERING for data recorded to reconstruct AS_DECLARED ordering
+  # - POINTER and FILE for data identifying definitions of certain objects
+  # - TYPE_NAME for property names of defined schema definitions
+  # - BAD_REF for information about unresolvable references
+  # You may also specify ALL or NONE
+  RETAIN_EXTENSION_DATA: "ALL"
+  
+  # Specify YAML, JSON, or BOTH (the default) to specify which form(s) of output file to produce
+  OUTPUTS: "BOTH"
+  
+  # In body parameters with x-examples vendor extension, convert non-text values into json-serialized text.
+  # This overcomes a bug in SwaggerParser that requires these examples to be text.
+  # This option applies only to v2 models.
+  FIX_X_EXAMPLES: true
+  
+  # Fold multi-line descriptions in YAML output.
+  foldMultiline: true

--- a/modules/gentemplates/openapi-normalizer/src/test/resources/petstore.yaml
+++ b/modules/gentemplates/openapi-normalizer/src/test/resources/petstore.yaml
@@ -1,0 +1,114 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:    
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        201:
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        birthDate:
+          type: string
+          format: date
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/modules/gentemplates/openapi3-doc/pom.xml
+++ b/modules/gentemplates/openapi3-doc/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/modules/gentemplates/rapidml-csharp/pom.xml
+++ b/modules/gentemplates/rapidml-csharp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-csharp</artifactId>

--- a/modules/gentemplates/rapidml-diagram/pom.xml
+++ b/modules/gentemplates/rapidml-diagram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-diagram</artifactId>

--- a/modules/gentemplates/rapidml-doc/pom.xml
+++ b/modules/gentemplates/rapidml-doc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-doc</artifactId>

--- a/modules/gentemplates/rapidml-jaxrs/pom.xml
+++ b/modules/gentemplates/rapidml-jaxrs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-jaxrs</artifactId>

--- a/modules/gentemplates/rapidml-jsonschema/pom.xml
+++ b/modules/gentemplates/rapidml-jsonschema/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-jsonschema</artifactId>

--- a/modules/gentemplates/rapidml-nodejs/pom.xml
+++ b/modules/gentemplates/rapidml-nodejs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-nodejs</artifactId>

--- a/modules/gentemplates/rapidml-swagger/pom.xml
+++ b/modules/gentemplates/rapidml-swagger/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-swagger</artifactId>

--- a/modules/gentemplates/rapidml-wadl/pom.xml
+++ b/modules/gentemplates/rapidml-wadl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-wadl</artifactId>

--- a/modules/gentemplates/rapidml-xsd/pom.xml
+++ b/modules/gentemplates/rapidml-xsd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>rapidml-xsd</artifactId>

--- a/modules/gentemplates/swagger-codegen/pom.xml
+++ b/modules/gentemplates/swagger-codegen/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-codegen</artifactId>

--- a/modules/gentemplates/swagger-doc/pom.xml
+++ b/modules/gentemplates/swagger-doc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../../</relativePath>
     </parent>
     <artifactId>swagger-doc</artifactId>

--- a/modules/gentemplates/swagger-nswag/pom.xml
+++ b/modules/gentemplates/swagger-nswag/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-nswag</artifactId>

--- a/modules/gentemplates/swagger-ui/pom.xml
+++ b/modules/gentemplates/swagger-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>swagger-ui</artifactId>

--- a/modules/standard-gentemplates/pom.xml
+++ b/modules/standard-gentemplates/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.reprezen.genflow</groupId>
         <artifactId>genflow</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.1-ZEN-4720-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>genflow-tools</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.reprezen.genflow</groupId>
     <artifactId>genflow</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1-ZEN-4720-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>GenFlow</name>
     <description>RepreZen GenFlow Framework</description>
@@ -274,12 +274,12 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>genflow-api</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>genflow-common</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.openapitools</groupId>
@@ -294,7 +294,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>standard-gentemplates</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
                 <type>pom</type>
             </dependency>
             <dependency>
@@ -305,7 +305,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-codegen</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -315,32 +315,32 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-diagram</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-generator</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi3-doc</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-doc</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>openapi-normalizer</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-ui</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.rapidml</groupId>
@@ -370,37 +370,37 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-doc</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-diagram</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-xsd</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-wadl</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-jsonschema</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-swagger</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-csharp</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -410,7 +410,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-nodejs</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
@@ -435,12 +435,12 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>rapidml-jaxrs</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>swagger-nswag</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -455,7 +455,7 @@
             <dependency>
                 <groupId>com.reprezen.genflow</groupId>
                 <artifactId>genflow-tests</artifactId>
-                <version>1.2.1-SNAPSHOT</version>
+                <version>1.2.1-ZEN-4720-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>


### PR DESCRIPTION
The Option PATH_OR_COMPONENTS could not be parsed by the NormalizerParameters because it was not defined. This is done by adding it in the specialRetainTypes map. 

Note the document mentions that the option is PATH_OR_COMPONENT in singular but the option in GenFlow is called PATH_OR_COMPONENTS (with components plural). The documentation has been updated to reflect that but I don't know if we should keep the previous one (singular) for backard compatibility.